### PR TITLE
Add middleware validation to check order status

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -1,6 +1,6 @@
 // importing express and other modules
 import express from 'express';
-import logger from 'volleyball';
+// import logger from 'volleyball';
 import bodyParser from 'body-parser';
 import validation from 'express-validator';
 
@@ -11,7 +11,7 @@ import routecontroller from './dummyApi/route/index';
 const app = express();
 
 // Log requests to the console.
-app.use(logger);
+// app.use(logger);
 
 // body-parser configuration
 app.use(bodyParser.json());

--- a/server/dummyApi/middleware/orderValidator.js
+++ b/server/dummyApi/middleware/orderValidator.js
@@ -39,13 +39,14 @@ class OrderValidator {
         req.checkBody('orderStatus', 'Order status must be a string').isString();
         req.checkParams('orderId', 'Order id must not be empty').notEmpty();
         req.checkParams('orderId', 'Order id must be an integer').isInt();
+        req.checkBody('orderStatus', 'Order status is either New, Processing, Cancelled or Complete').isIn(['New', 'Processing', 'Cancelled', 'Complete']);
 
         const errors = req.validationErrors();
 
         if (errors) {
             return res.status(404).json({
                 status: 'Failure',
-                message: 'Validation not sucessful',
+                message: 'Validation not successful',
                 data: errors,
             });
         }
@@ -68,6 +69,7 @@ class OrderValidator {
         req.checkBody('qty', 'Quantity must be an integer').isInt();
         req.checkBody('orderStatus', 'Order status must not be empty').notEmpty();
         req.checkBody('orderStatus', 'Order status must be a string').isString();
+        req.checkBody('orderStatus', 'Order status is either New, Processing, Cancelled or Complete').isIn(['New', 'Processing', 'Cancelled', 'Complete']);
         req.checkBody('deliveryAddress', 'Delivery address must not be empty').notEmpty();
         req.checkBody('deliveryAddress', 'Delivery address must be a string').isString();
         // req.checkBody('foodId', 'food id must not be empty').notEmpty().isInt();

--- a/server/tests/orders.tests.js
+++ b/server/tests/orders.tests.js
@@ -11,7 +11,7 @@ describe('Order Controller', () => {
         foodName: 'Meat Pie',
         foodPrice: 250,
         qty: 9,
-        orderStatus: 'Completed',
+        orderStatus: 'Complete',
         deliveryAddress: '29, Ikorodu road Lagos'
     };
 
@@ -25,11 +25,12 @@ describe('Order Controller', () => {
                 expect(res.body.status).to.equal('Success');
                 expect(res.body.message).to.equal('New order was created');
                 expect(res.body.data.orderId).to.be.eql(4);
-                expect(res.body.data.orderStatus).to.be.eql('Completed');
+                expect(res.body.data.orderStatus).to.be.eql('Complete');
                 expect(res.body.data.totalAmount).to.be.eql(2250);
                 done(err);
             });
     });
+
 
     // test for posting an order with an empty food name
     it('should not create a new order with an empty food name', (done) => {
@@ -37,7 +38,7 @@ describe('Order Controller', () => {
             foodName: '',
             foodPrice: 250,
             qty: 9,
-            orderStatus: 'Completed',
+            orderStatus: 'Complete',
             deliveryAddress: '29, Ikorodu road Lagos'
         };
         chai.request(server)
@@ -58,7 +59,7 @@ describe('Order Controller', () => {
             foodName: 2,
             foodPrice: 250,
             qty: 9,
-            orderStatus: 'Completed',
+            orderStatus: 'Complete',
             deliveryAddress: '29, Ikorodu road Lagos'
         };
         chai.request(server)
@@ -80,7 +81,7 @@ describe('Order Controller', () => {
             foodName: 'Meat Pie',
             foodPrice: '',
             qty: 9,
-            orderStatus: 'Completed',
+            orderStatus: 'Complete',
             deliveryAddress: '29, Ikorodu road Lagos'
         };
         chai.request(server)
@@ -101,7 +102,7 @@ describe('Order Controller', () => {
             foodName: 'Meat Pie',
             foodPrice: 'hi',
             qty: 9,
-            orderStatus: 'Completed',
+            orderStatus: 'Complete',
             deliveryAddress: '29, Ikorodu road Lagos'
         };
         chai.request(server)
@@ -122,7 +123,7 @@ describe('Order Controller', () => {
             foodName: 'Meat Pie',
             foodPrice: 300,
             qty: 'hello',
-            orderStatus: 'Completed',
+            orderStatus: 'Complete',
             deliveryAddress: '29, Ikorodu road Lagos'
         };
         chai.request(server)
@@ -182,7 +183,7 @@ describe('Order Controller', () => {
                 expect(res.body.data.orderId).to.be.eql(4);
                 expect(res.body.data.userId).to.be.eql(4);
                 expect(res.body.data.totalAmount).to.be.eql(2250);
-                expect(res.body.data.orderStatus).to.be.eql('Completed');
+                expect(res.body.data.orderStatus).to.be.eql('Complete');
                 done(err);
             });
     });
@@ -215,7 +216,7 @@ describe('Order Controller', () => {
     // test for updating the status of an order
     it('should update an order', (done) => {
         const updateOrder = {
-            orderStatus: 'Pending',
+            orderStatus: 'New',
         };
         chai.request(server)
             .put('/api/v1/orders/3')
@@ -230,7 +231,7 @@ describe('Order Controller', () => {
     // test for updating the status of a not existing order
     it('should throw a 404 error when wanting to update a non-existent order', (done) => {
         const updateOrder = {
-            orderStatus: 'Pending',
+            orderStatus: 'Complete',
         };
         chai.request(server)
             .put('/api/v1/orders/40')
@@ -245,10 +246,27 @@ describe('Order Controller', () => {
             });
     });
 
+    // test for updating the status of an order using random strings
+    it('should not update an order using random strings', (done) => {
+        const updateOrder = {
+            orderStatus: 'kkljhgf',
+        };
+        chai.request(server)
+            .put('/api/v1/orders/3')
+            .send(updateOrder)
+            .end((err, res) => {
+                expect(res.status).to.equal(404);
+                expect(res.body.status).to.be.eql('Failure');
+                expect(res.body.message).to.be.eql('Validation not successful');
+                expect(res.body.data[0].msg).to.be.eql('Order status is either New, Processing, Cancelled or Complete');
+                done(err);
+            });
+    });
+
     // test for updating the status of an order with a string id
     it('should throw an error when trying to update a string order id', (done) => {
         const updateOrder = {
-            orderStatus: 'Pending',
+            orderStatus: 'Processing',
         };
         chai.request(server)
             .put('/api/v1/orders/u')
@@ -256,7 +274,7 @@ describe('Order Controller', () => {
             .end((err, res) => {
                 expect(res.status).to.equal(404);
                 expect(res.body.status).to.be.eql('Failure');
-                expect(res.body.message).to.be.eql('Validation not sucessful');
+                expect(res.body.message).to.be.eql('Validation not successful');
                 expect(res.body.data[0].msg).to.be.eql('Order id must be an integer');
                 done(err);
             });
@@ -289,7 +307,7 @@ describe('Order Controller', () => {
             .end((err, res) => {
                 expect(res.status).to.equal(404);
                 expect(res.body.status).to.be.eql('Failure');
-                expect(res.body.message).to.be.eql('Validation not sucessful');
+                expect(res.body.message).to.be.eql('Validation not successful');
                 expect(res.body.data[0].msg).to.be.eql('Order status must be a string');
                 done(err);
             });


### PR DESCRIPTION
#### What does this PR do?
It prevents the orderStatus of an order to be updated with any random string


#### Description of Task to be completed?
has a middleware to check the orderStatus


#### How should this be manually tested?
- Run `npm run start` on the terminal
- use postman to update the orderStatus of an order using `http://localhost:8000/api/v1/orders/:orderId`	


#### Any background context you want to provide?
N/A


#### What are the relevant pivotal tracker stories? (If applicable)
#160743524


#### Screenshots (If applicable)
![order-status](https://user-images.githubusercontent.com/32887459/45987070-744a7000-c067-11e8-8e94-a58743a262d0.jpg)
